### PR TITLE
chore: scheduled harvest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>3.3.4</version>
+      <version>3.4.3</version>
       <relativePath/>
     </parent>
 
@@ -29,9 +29,9 @@
         <maven.exec.skip>false</maven.exec.skip>
         <!--end standard properties-->
 
-        <kotlin.version>2.0.21</kotlin.version>
-        <testcontainers.version>1.20.2</testcontainers.version>
-        <jena.version>5.2.0</jena.version>
+        <kotlin.version>2.1.10</kotlin.version>
+        <testcontainers.version>1.20.5</testcontainers.version>
+        <jena.version>5.3.0</jena.version>
     </properties>
 
     <dependencies>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>1.9.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
@@ -128,13 +128,13 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.9.1</version>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.3.1</version>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -274,7 +274,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <argLine>${surefire.jacoco.args}</argLine>
@@ -288,7 +288,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <argLine>${failsafe.jacoco.args}</argLine>
                     <groups>contract</groups>

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/Application.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/Application.kt
@@ -3,11 +3,13 @@ package no.digdir.informasjonsforvaltning.fdk_dataservice_harvester
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableWebSecurity
+@EnableScheduling
 open class Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/harvester/HarvesterActivity.kt
@@ -15,6 +15,7 @@ import no.digdir.informasjonsforvaltning.fdk_dataservice_harvester.service.Updat
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.Calendar
 import kotlin.time.measureTimedValue
@@ -34,6 +35,10 @@ class HarvesterActivity(
 
     @EventListener
     private fun fullHarvestOnStartup(event: ApplicationReadyEvent) =
+        initiateHarvest(HarvestAdminParameters(null, null, null), false)
+
+    @Scheduled(cron = "0 15 * * * *")
+    fun scheduledHarvest() =
         initiateHarvest(HarvestAdminParameters(null, null, null), false)
 
     fun initiateHarvest(params: HarvestAdminParameters, forceUpdate: Boolean) {

--- a/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/ApiTestContainer.kt
+++ b/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/ApiTestContainer.kt
@@ -1,5 +1,6 @@
 package no.digdir.informasjonsforvaltning.fdk_dataservice_harvester.utils
 
+import org.junit.jupiter.api.BeforeEach
 import org.slf4j.LoggerFactory
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.boot.test.web.server.LocalServerPort
@@ -15,6 +16,11 @@ abstract class ApiTestContext {
 
     @LocalServerPort
     var port: Int = 0
+
+    @BeforeEach
+    fun resetDatabase() {
+        resetDB()
+    }
 
     internal class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
         override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
@@ -39,8 +45,6 @@ abstract class ApiTestContext {
                 .waitingFor(Wait.forListeningPort())
 
             mongoContainer.start()
-
-            populateDB()
 
             try {
                 val con = URL("http://localhost:5050/ping").openConnection() as HttpURLConnection

--- a/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/DatabaseData.kt
+++ b/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/DatabaseData.kt
@@ -48,7 +48,12 @@ val REMOVED_DATA_SERVICE_DBO = DataServiceMeta(
 
 val UNION_DATA = TurtleDBO(
     id = catalogTurtleID(UNION_ID, true),
-    turtle = gzip(responseReader.readFile("catalog_0.ttl"))
+    turtle = gzip(responseReader.readFile("all_catalogs.ttl"))
+)
+
+val UNION_DATA_NO_RECORDS = TurtleDBO(
+    id = catalogTurtleID(UNION_ID, false),
+    turtle = gzip(responseReader.readFile("all_catalogs_no_records.ttl"))
 )
 
 val HARVEST_DBO_0 = TurtleDBO(
@@ -113,7 +118,7 @@ val REMOVED_DATA_SERVICE_TURTLE_NO_RECORDS = TurtleDBO(
 
 fun turtleDBPopulation(): List<Document> =
     listOf(
-        UNION_DATA, HARVEST_DBO_0, HARVEST_DBO_1, CATALOG_TURTLE_0, CATALOG_TURTLE_0_NO_RECORDS,
+        UNION_DATA, UNION_DATA_NO_RECORDS, HARVEST_DBO_0, HARVEST_DBO_1, CATALOG_TURTLE_0, CATALOG_TURTLE_0_NO_RECORDS,
         CATALOG_TURTLE_1, CATALOG_TURTLE_1_NO_RECORDS, DATA_SERVICE_TURTLE_0, DATA_SERVICE_TURTLE_0_NO_RECORDS,
         DATA_SERVICE_TURTLE_1, DATA_SERVICE_TURTLE_1_NO_RECORDS, REMOVED_DATA_SERVICE_TURTLE, REMOVED_DATA_SERVICE_TURTLE_NO_RECORDS
     )

--- a/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/TestUtils.kt
+++ b/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataservice_harvester/utils/TestUtils.kt
@@ -92,7 +92,7 @@ private fun isOK(response: Int?): Boolean =
     if (response == null) false
     else HttpStatus.resolve(response)?.is2xxSuccessful == true
 
-fun populateDB() {
+fun resetDB() {
     val connectionString =
         ConnectionString("mongodb://${MONGO_USER}:${MONGO_PASSWORD}@localhost:${mongoContainer.getMappedPort(MONGO_PORT)}/dataServiceHarvester?authSource=admin&authMechanism=SCRAM-SHA-1")
     val pojoCodecRegistry = CodecRegistries.fromRegistries(
@@ -104,12 +104,15 @@ fun populateDB() {
     val mongoDatabase = client.getDatabase("dataServiceHarvester").withCodecRegistry(pojoCodecRegistry)
 
     val miscCollection = mongoDatabase.getCollection("turtle")
+    miscCollection.deleteMany(org.bson.Document())
     miscCollection.insertMany(turtleDBPopulation())
 
     val catalogCollection = mongoDatabase.getCollection("catalogMeta")
+    catalogCollection.deleteMany(org.bson.Document())
     catalogCollection.insertMany(catalogDBPopulation())
 
     val serviceCollection = mongoDatabase.getCollection("dataserviceMeta")
+    serviceCollection.deleteMany(org.bson.Document())
     serviceCollection.insertMany(serviceDBPopulation())
 
     client.close()


### PR DESCRIPTION
Fra slack:

> prøvde å oppdatere fdk-harvest-scheduler på fredag, men den får nå en mystisk Killed melding på ca 50% av kjøringene sine i staging, også når jeg går tilbake til forrige versjon av image. Ble litt lei av å måtte fikse komplisert feil i en applikasjon jeg synes vi bare burde stenge ned, så tok meg den friheten å stenge den ned i staging og oppretta en pr på hver høster med hva som skal til for å kunne stenge den ned.
> 
> https://github.com/Informasjonsforvaltning/fdk-dataset-harvester/pull/258
> https://github.com/Informasjonsforvaltning/fdk-concept-harvester/pull/203
> https://github.com/Informasjonsforvaltning/fdk-dataservice-harvester/pull/205
> https://github.com/Informasjonsforvaltning/fdk-informationmodel-harvester/pull/180
> https://github.com/Informasjonsforvaltning/fdk-event-harvester/pull/136
> https://github.com/Informasjonsforvaltning/fdk-public-service-harvester/pull/152
> 
> Det vil resultere i at høsterene selv holder på schedule for de høstingene som kjøres automatisk, i stedet for at de lytter til rabbit-meldingene som fdk-harvest-scheduler sender. Er dette ok? Isf kan vi stenge ned og arkivere fdk-harvest-scheduler