### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.draft == false
     permissions:
       contents: read
-      packages: read
+      security-events: write
     uses: Informasjonsforvaltning/workflows/.github/workflows/codeql.yaml@main
     with:
       language: java

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,6 +15,9 @@ jobs:
   codeql:
     name: Run codeql scan
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      packages: read
     uses: Informasjonsforvaltning/workflows/.github/workflows/codeql.yaml@main
     with:
       language: java


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/fdk-dataservice-harvester/security/code-scanning/4](https://github.com/Informasjonsforvaltning/fdk-dataservice-harvester/security/code-scanning/4)

To fix the problem, explicitly define the `permissions` for the `GITHUB_TOKEN` in this workflow, scoping them as narrowly as possible. Since this workflow only triggers code scanning via a reusable workflow and does not itself modify repository contents, a conservative and generally safe default is read-only access to code and packages (`contents: read`, `packages: read`). This aligns with GitHub’s recommended minimal baseline for many CI workflows and documents that the workflow does not need write privileges.

The best fix without changing existing functionality is to add a `permissions` block at the job level for `codeql`. That way, even if the repository’s default token permissions are read-write, this job will run with restricted read-only permissions. Specifically, in `.github/workflows/codeql.yaml`, under `jobs:`, inside the `codeql:` job and alongside `name`, `if`, and `uses`, add:

```yaml
    permissions:
      contents: read
      security-events: write
```

No additional imports, methods, or definitions are required because this is a pure workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
